### PR TITLE
タグ一覧の色修正，memolistのソート機能，表示形式変更機能実装

### DIFF
--- a/front-end/front-app/src/pages/components/left/tagToggle.tsx
+++ b/front-end/front-app/src/pages/components/left/tagToggle.tsx
@@ -10,7 +10,7 @@ const TagToggle: React.FC<TagToggleProps> = ({ onToggle, showTags }) => {
     <div>
       <button 
         onClick={onToggle}
-        style={{ border: "none", background: "none" }} // ボーダーと背景を非表示に
+        style={{ border: "none", background: "none", color: "#808080"}} // ボーダーと背景を非表示に
         >
         {showTags ? "タグ一覧▲" : "タグ一覧▼"}
       </button>

--- a/front-end/front-app/src/pages/components/memoList.tsx
+++ b/front-end/front-app/src/pages/components/memoList.tsx
@@ -4,12 +4,32 @@ import styles from "../../styles/memoList.module.css";
 import Memo from "./memoTypeDef"
  
 const MemoList = ( {setSelectedMemo}:{setSelectedMemo:any}) => {
+    const [sortByNewest, setSortByNewest] = useState(true); // 初期値を新しい順に設定
+    const [displayInGrid, setDisplayInGrid] = useState(true); // 初期値をグリッド表示に設定
+
     const handleMemoClick = (memo: Memo) => {
       setSelectedMemo(memo);
     };
 
-    const newSortedMemos = [...memos].sort((a, b) => b.date - a.date);
+    // const newSortedMemos = [...memos].sort((a, b) => b.date - a.date);
     // const oldSortedMemos = [...memos].sort((a, b) => b.date - a.date);
+    const sortedMemos = [...memos].sort((a, b) => {
+        // ソート方法に応じて比較
+        if (sortByNewest) {
+          return b.date - a.date;
+        } else {
+          return a.date - b.date;
+        }
+      });
+
+    const toggleSortOrder = () => {
+        setSortByNewest((prevSort) => !prevSort); // ソート方法をトグル
+    };
+    const toggleDisplayFormat = () => {
+        setDisplayInGrid((grid) => !grid); // 表示形式をトグル
+    };
+
+
   
     return (
        // ソート方法，表示形式で変える
@@ -17,19 +37,40 @@ const MemoList = ( {setSelectedMemo}:{setSelectedMemo:any}) => {
        {/* ヘッダー */}
        <div className={styles.header}>
            <div className={styles.searchResult}>ホーム：</div>
-           <button className={styles.sortFormat}>ソート：新しい順</button>
+           <button className={styles.sortFormat} onClick={toggleSortOrder}>
+                {sortByNewest ? "ソート：新しい順" : "ソート：古い順"}
+            </button>
        </div>
 
-          {newSortedMemos.map((memo, index) => (
+          {sortedMemos.map((memo, index) => (
             <button
                 key={index}
-                className={styles.memoContainer}
+                className={`${styles.memoContainer} ${displayInGrid ? styles.memoContainerGrid : styles.memoContainerBar}`}
                 onClick={() => handleMemoClick(memo)}
             >
-                <h3 className={styles.memoTitle}>{truncateTitle(memo.title)}</h3>
-                <p className={styles.memoTags}>{truncateTags(renderTags(memo.tag))}</p>
-                <p className={styles.memoComment}>{truncateComment(memo.comment)}</p>
-                <p className={styles.memoDate}>{formatDate(memo.date)}</p>
+                {/* タイトル */}
+                <h3 className={`${styles.memoTitle} ${displayInGrid ? styles.memoTitleGrid : styles.memoTitleBar}`}>
+                    {displayInGrid ? truncateTitle(memo.title): truncateTitleBar(memo.title)}
+                </h3>
+                {/* タグ */}
+                <p className={`${styles.memoTags} ${displayInGrid ? styles.memoTagsGrid : styles.memoTagsBar}`}>
+                    {truncateTags(renderTags(memo.tag))}
+                </p>
+                {/* コメント */}
+                {displayInGrid && (
+                    <p className={styles.memoCommentGrid}>
+                        {truncateComment(memo.comment)}
+                    </p>
+                )}
+                {/* <p className={`${styles.memoComment} ${displayInGrid ? styles.memoCommentGrid : styles.memoCommentBar}`}>
+                    {truncateComment(memo.comment)}
+                </p> */}
+                {/* 日付 */}
+                {displayInGrid && (
+                    <p className={styles.memoDate}>
+                        {formatDate(memo.date)}
+                    </p>
+                )}
             </button>
           ))}
         {/* <div className={styles.selectedMemoContainer}>
@@ -45,8 +86,8 @@ const MemoList = ( {setSelectedMemo}:{setSelectedMemo:any}) => {
         
         {/* フッター */}
         <div className={styles.footer}>
-            <button className={styles.displayFormat}>
-                表示形式：
+            <button className={styles.displayFormat} onClick={toggleDisplayFormat}>
+                {displayInGrid ? "表示形式：グリッド" : "表示形式：横長"}
             </button>
         </div>
 
@@ -58,6 +99,14 @@ const MemoList = ( {setSelectedMemo}:{setSelectedMemo:any}) => {
 const truncateTitle = (title: string) => {
     if (title.length > 10) {
         return title.substring(0, 9) + "…";
+    }
+    return title;
+  };
+
+// 表示形式がバーのとき，タイトルが30文字以上のとき，88文字目まで+"…"の形式にフォーマットする関数
+const truncateTitleBar = (title: string) => {
+    if (title.length > 30) {
+        return title.substring(0, 28) + "…";
     }
     return title;
   };

--- a/front-end/front-app/src/styles/leftside.module.css
+++ b/front-end/front-app/src/styles/leftside.module.css
@@ -46,6 +46,7 @@
     text-decoration: underline;
 }
 .tag-button {
+    color: #808080;
     border: none;
     background-color: transparent;
     cursor: pointer;

--- a/front-end/front-app/src/styles/memoList.module.css
+++ b/front-end/front-app/src/styles/memoList.module.css
@@ -68,8 +68,32 @@
     background-color: #E9E9E9;
   }
   
+.memoContainerBar{
+    background-color: #ffffff;
+    color: #c1c1c1;
+    border: 1px solid #c1c1c1;
+    border-radius: 0px;
+    height: 70px;
+    width: 100%;
+    margin: 0px;
+    /* padding: 10px; */
+    display: flex;
+    flex-direction: column; /* コンテンツを縦方向に配置 */
+    align-items: flex-start; /* 左寄せに配置 */
+    transition: background-color 0.3s ease-in-out; /* トランジションを追加 */
+}
+
+.memoContainer:hover { /* カーソルを合わせたときのスタイルを追加 */
+    background-color: #E9E9E9;
+  }
   
-.memoTitle {
+  
+.memoTitleGrid {
+    font-size: 20px;
+    /* font-style: italic; */
+    color: #808080;
+}
+.memoTitleBar {
     font-size: 20px;
     /* font-style: italic; */
     color: #808080;
@@ -79,11 +103,21 @@
     font-size: 16px;
     color: #808080;
 }
+.memoTagsBar {
+    font-size: 12px;
+    color: #808080;
+}
   
-.memoComment {
+.memoCommentGrid {
     font-size: 16px;
     color: #808080;
     margin-top: 5px;
+    text-align: left; /* 左揃えにするために追加 */
+}
+.memoCommentBar {
+    font-size: 8px;
+    color: #808080;
+    margin-top: 0px;
     text-align: left; /* 左揃えにするために追加 */
 }
   


### PR DESCRIPTION
front-end/front-app/src/pages/components/left/tagToggle.tsx　「タグ一覧▼」の文字色変更
front-end/front-app/src/styles/leftside.module.css タグ一覧を開いたときのタグの文字色変更
front-end/front-app/src/pages/components/memoList.tsx　ソート新しい順と古い順切り替え実装，表示形式をグリッドとバー切り替え実装
front-end/front-app/src/styles/memoList.module.css　ソート，表示形式にそって追加，変更