### PR TITLE
fixed tag struct's syntax error

### DIFF
--- a/back-end/app-plate/data/tag.go
+++ b/back-end/app-plate/data/tag.go
@@ -10,7 +10,7 @@ import (
 // <-------Tagオブジェクト-----
 type Tag struct {
 	Id      int    `json:"id"`
-	TagName string `json:"name`
+	TagName string `json:"name"`
 	UserId  string
 	MemoNum int `json:"memoNum"`
 }


### PR DESCRIPTION
fixed: struct field tag `json:"name` not compatible with reflect.StructTag.Get: bad syntax for struct tag value